### PR TITLE
Return 400 request errors from Shippo

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -131,7 +131,7 @@ Resource.prototype = {
         } else if (res.statusCode === 400) {
           err = new Error.ShippoAPIError({
             message: 'The data you sent was not accepted as valid',
-            detail: response.__all__
+            detail: response,
           });
         }
         if (err) {


### PR DESCRIPTION
Currently the `detail` field equals `response.__all__`, which is undefined.
Instead, pass back the body of the response.
